### PR TITLE
Portenta external qspi flash driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ west flash
 - [X] uart console
 - [ ] power mangement
 - [ ] memory controller
+- [X] external flash memory 
 - [X] led driver
 - [ ] charger driver
 - [ ] wifi / ble

--- a/boards/arm/portenta_h7/portenta_h7.dtsi
+++ b/boards/arm/portenta_h7/portenta_h7.dtsi
@@ -202,3 +202,11 @@
     };
 };
 
+&quadspi {
+    pinctrl-names = "default";
+    pinctrl-0 = <&quadspi_clk_pf10 &quadspi_bk1_ncs_pg6
+                 &quadspi_bk1_io0_pd11 &quadspi_bk1_io1_pd12
+                 &quadspi_bk1_io2_pf7 &quadspi_bk1_io3_pd13>;
+
+    status = "disabled";
+};

--- a/boards/arm/portenta_h7/portenta_h7_m7.dts
+++ b/boards/arm/portenta_h7/portenta_h7_m7.dts
@@ -114,6 +114,7 @@
         compatible = "zephyr,cdc-acm-uart";
         label = "CDC_ACM_0";
         status = "okay";
+    };
 };
 
 &quadspi {

--- a/boards/arm/portenta_h7/portenta_h7_m7.dts
+++ b/boards/arm/portenta_h7/portenta_h7_m7.dts
@@ -114,5 +114,19 @@
         compatible = "zephyr,cdc-acm-uart";
         label = "CDC_ACM_0";
         status = "okay";
+};
+
+&quadspi {
+    status = "okay";
+
+    flash-id = <1>;
+
+    mx25l12833f: qspi-nor-flash@0 {
+      compatible = "st,stm32-qspi-nor";
+      label = "mx25l12833f";
+      reg = <0>;
+      qspi-max-frequency = <133000000>;
+      size = <DT_SIZE_M(16*8)>;
+      status = "okay";
     };
 };

--- a/boards/arm/portenta_h7/portenta_h7_m7.dts
+++ b/boards/arm/portenta_h7/portenta_h7_m7.dts
@@ -121,12 +121,13 @@
     status = "okay";
 
     flash-id = <1>;
+    spi-bus-width = <4>;
 
     mx25l12833f: qspi-nor-flash@0 {
       compatible = "st,stm32-qspi-nor";
       label = "mx25l12833f";
       reg = <0>;
-      qspi-max-frequency = <133000000>;
+      qspi-max-frequency = <100000000>;
       size = <DT_SIZE_M(16*8)>;
       status = "okay";
     };

--- a/boards/arm/portenta_h7/portenta_h7_m7.dts
+++ b/boards/arm/portenta_h7/portenta_h7_m7.dts
@@ -121,13 +121,13 @@
     status = "okay";
 
     flash-id = <1>;
-    spi-bus-width = <4>;
 
     mx25l12833f: qspi-nor-flash@0 {
       compatible = "st,stm32-qspi-nor";
       label = "mx25l12833f";
       reg = <0>;
       qspi-max-frequency = <100000000>;
+      spi-bus-width = <4>;
       size = <DT_SIZE_M(16*8)>;
       status = "okay";
     };


### PR DESCRIPTION
integrate qspi flash driver in zephyr

- using jesd216 standard driver
- quad mode enable & tested
